### PR TITLE
Create Angular template builder and viewer workspace

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,10 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers.
+# For additional information see https://github.com/browserslist/browserslist#readme
+
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
+Firefox ESR
+not IE 11

--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "developer-portal": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/developer-portal",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": [],
+            "tsConfig": "tsconfig.app.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "developer-portal:build:production"
+            },
+            "development": {
+              "browserTarget": "developer-portal:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "developer-portal:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "developer-portal"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,39 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/6.4/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/developer-portal'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "developer-portal",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "rxjs": "~7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "~0.14.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.0",
+    "@angular/cli": "^17.3.0",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.1",
+    "karma": "~6.4.2",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { TemplateManagerComponent } from './components/template-manager/template-manager.component';
+import { ViewerComponent } from './components/viewer/viewer.component';
+
+const routes: Routes = [
+  { path: 'templates', component: TemplateManagerComponent },
+  { path: 'viewer', component: ViewerComponent },
+  { path: '', redirectTo: 'templates', pathMatch: 'full' },
+  { path: '**', redirectTo: 'templates' },
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes, { bindToComponentInputs: true })],
+  exports: [RouterModule],
+})
+export class AppRoutingModule {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,23 @@
+<header class="app-header">
+  <div class="container header-content">
+    <div class="branding">
+      <span class="logo">📚</span>
+      <div>
+        <h1>{{ title }}</h1>
+        <p class="tagline">Design reusable publishing templates and assemble catalogs in the browser.</p>
+      </div>
+    </div>
+    <nav class="main-nav">
+      <a routerLink="/templates" routerLinkActive="active">Template studio</a>
+      <a routerLink="/viewer" routerLinkActive="active">Content workspace</a>
+    </nav>
+  </div>
+</header>
+<main class="container">
+  <router-outlet></router-outlet>
+</main>
+<footer class="app-footer">
+  <div class="container">
+    <small>Local storage is used for persistence. Add your backend later without losing progress.</small>
+  </div>
+</footer>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,62 @@
+.app-header {
+  background: linear-gradient(135deg, #3f51b5, #6574cd);
+  color: #fff;
+  padding: 1.25rem 0;
+  box-shadow: 0 6px 18px rgba(63, 81, 181, 0.25);
+}
+
+.header-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo {
+  font-size: 2.5rem;
+}
+
+.tagline {
+  margin: 0;
+  opacity: 0.9;
+}
+
+.main-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.main-nav a {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.35rem 0.6rem;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+}
+
+.main-nav a.active,
+.main-nav a:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.app-footer {
+  background: #111827;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 1.25rem 0;
+  margin-top: 2rem;
+}
+
+.app-footer small {
+  font-size: 0.85rem;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+})
+export class AppComponent {
+  title = 'Developer Portal Templates';
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { TemplateManagerComponent } from './components/template-manager/template-manager.component';
+import { ViewerComponent } from './components/viewer/viewer.component';
+
+@NgModule({
+  declarations: [AppComponent, TemplateManagerComponent, ViewerComponent],
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, RouterModule, AppRoutingModule],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}

--- a/src/app/components/template-manager/template-manager.component.html
+++ b/src/app/components/template-manager/template-manager.component.html
@@ -1,0 +1,215 @@
+<section class="card">
+  <div class="section-header">
+    <div>
+      <h2>Template studio</h2>
+      <p class="section-description">
+        Define reusable layouts for pages, group them into books, and connect books inside a catalog blueprint.
+      </p>
+    </div>
+    <button class="btn btn-secondary" type="button" (click)="resetAllData()">Reset everything</button>
+  </div>
+
+  <form class="form-grid" [formGroup]="pageTemplateForm" (ngSubmit)="submitPageTemplate()">
+    <h3>Page template</h3>
+    <div class="form-grid two-column">
+      <label>
+        Name
+        <input type="text" formControlName="name" placeholder="Article page" />
+      </label>
+      <label>
+        Description
+        <input type="text" formControlName="description" placeholder="Short summary" />
+      </label>
+    </div>
+
+    <div class="field-builder" [formGroup]="fieldDraftForm">
+      <h4>Add page fields</h4>
+      <div class="inline-fields">
+        <label>
+          Label
+          <input type="text" formControlName="name" placeholder="Title" />
+        </label>
+        <label>
+          Type
+          <select formControlName="type">
+            <option *ngFor="let fieldType of fieldTypes" [value]="fieldType.value">{{ fieldType.label }}</option>
+          </select>
+        </label>
+        <label>
+          Helper text
+          <input type="text" formControlName="description" placeholder="Visible hint (optional)" />
+        </label>
+        <button type="button" class="btn btn-secondary" (click)="addField()">Add field</button>
+      </div>
+    </div>
+
+    <div *ngIf="fields.controls.length > 0; else emptyFields" class="field-list">
+      <h4>Preview</h4>
+      <ul class="list">
+        <li class="list-item" *ngFor="let field of fields.controls; let i = index; trackBy: trackByIndex">
+          <div class="section-header">
+            <div>
+              <strong>{{ (field.value as any).name }}</strong>
+              <span class="tag">{{ getFieldLabel((field.value as any).type) }}</span>
+            </div>
+            <button type="button" class="btn btn-secondary" (click)="removeField(i)">Remove</button>
+          </div>
+          <p class="muted" *ngIf="(field.value as any).description">{{ (field.value as any).description }}</p>
+        </li>
+      </ul>
+    </div>
+    <ng-template #emptyFields>
+      <p class="empty-state">Add at least one field to save this page template.</p>
+    </ng-template>
+
+    <div class="form-actions">
+      <button class="btn btn-primary" type="submit">Save page template</button>
+      <button class="btn btn-secondary" type="button" (click)="resetPageTemplateForm()">Clear form</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Existing page templates</h3>
+  <ng-container *ngIf="pageTemplates$ | async as pageTemplates; else emptyPageTemplates">
+    <ul class="list" *ngIf="pageTemplates.length > 0; else emptyPageTemplates">
+      <li class="list-item" *ngFor="let template of pageTemplates; trackBy: trackById">
+        <div class="section-header">
+          <div>
+            <strong>{{ template.name }}</strong>
+            <p class="muted" *ngIf="template.description">{{ template.description }}</p>
+          </div>
+          <button class="btn btn-secondary" type="button" (click)="deletePageTemplate(template.id)">
+            Delete
+          </button>
+        </div>
+        <div class="badge-group">
+          <span class="tag" *ngFor="let field of template.fields">{{ field.name }} · {{ getFieldLabel(field.type) }}</span>
+        </div>
+      </li>
+    </ul>
+  </ng-container>
+</section>
+<ng-template #emptyPageTemplates>
+  <p class="empty-state">No page templates yet. Create one above.</p>
+</ng-template>
+
+<section class="card">
+  <form class="form-grid" [formGroup]="bookTemplateForm" (ngSubmit)="submitBookTemplate()">
+    <h3>Book template</h3>
+    <p class="section-description">
+      Select the page templates that compose a book. The order defines the expected flow for book builders.
+    </p>
+    <div class="form-grid two-column">
+      <label>
+        Name
+        <input type="text" formControlName="name" placeholder="Product handbook" />
+      </label>
+      <label>
+        Description
+        <input type="text" formControlName="description" placeholder="Purpose (optional)" />
+      </label>
+    </div>
+    <label>
+      Required page templates
+      <select formControlName="pageTemplateIds" multiple size="5">
+        <option *ngFor="let template of (pageTemplates$ | async) ?? []" [value]="template.id">
+          {{ template.name }}
+        </option>
+      </select>
+    </label>
+    <div class="form-actions">
+      <button class="btn btn-primary" type="submit">Save book template</button>
+      <button class="btn btn-secondary" type="button" (click)="bookTemplateForm.reset({ name: '', description: '', pageTemplateIds: [] })">
+        Clear form
+      </button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Existing book templates</h3>
+  <ng-container *ngIf="(bookTemplates$ | async) as bookTemplates; else emptyBookTemplates">
+    <ul class="list" *ngIf="bookTemplates.length > 0; else emptyBookTemplates">
+      <li class="list-item" *ngFor="let template of bookTemplates; trackBy: trackById">
+        <div class="section-header">
+          <div>
+            <strong>{{ template.name }}</strong>
+            <p class="muted" *ngIf="template.description">{{ template.description }}</p>
+          </div>
+          <button class="btn btn-secondary" type="button" (click)="deleteBookTemplate(template.id)">
+            Delete
+          </button>
+        </div>
+        <div class="badge-group">
+          <span class="tag" *ngFor="let pageId of template.pageTemplateIds">
+            {{ (pageTemplates$ | async)?.find((page) => page.id === pageId)?.name || 'Unknown page' }}
+          </span>
+        </div>
+      </li>
+    </ul>
+  </ng-container>
+</section>
+<ng-template #emptyBookTemplates>
+  <p class="empty-state">No book templates yet. Combine page templates to create one.</p>
+</ng-template>
+
+<section class="card">
+  <form class="form-grid" [formGroup]="catalogTemplateForm" (ngSubmit)="submitCatalogTemplate()">
+    <h3>Catalog template</h3>
+    <p class="section-description">
+      Group book templates to outline complete catalogs. Builders will connect finished books that match these blueprints.
+    </p>
+    <div class="form-grid two-column">
+      <label>
+        Name
+        <input type="text" formControlName="name" placeholder="Spring release catalog" />
+      </label>
+      <label>
+        Description
+        <input type="text" formControlName="description" placeholder="Optional context" />
+      </label>
+    </div>
+    <label>
+      Book templates in this catalog
+      <select formControlName="bookTemplateIds" multiple size="5">
+        <option *ngFor="let template of (bookTemplates$ | async) ?? []" [value]="template.id">
+          {{ template.name }}
+        </option>
+      </select>
+    </label>
+    <div class="form-actions">
+      <button class="btn btn-primary" type="submit">Save catalog template</button>
+      <button class="btn btn-secondary" type="button" (click)="catalogTemplateForm.reset({ name: '', description: '', bookTemplateIds: [] })">
+        Clear form
+      </button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Existing catalog templates</h3>
+  <ng-container *ngIf="(catalogTemplates$ | async) as catalogTemplates; else emptyCatalogTemplates">
+    <ul class="list" *ngIf="catalogTemplates.length > 0; else emptyCatalogTemplates">
+      <li class="list-item" *ngFor="let template of catalogTemplates; trackBy: trackById">
+        <div class="section-header">
+          <div>
+            <strong>{{ template.name }}</strong>
+            <p class="muted" *ngIf="template.description">{{ template.description }}</p>
+          </div>
+          <button class="btn btn-secondary" type="button" (click)="deleteCatalogTemplate(template.id)">
+            Delete
+          </button>
+        </div>
+        <div class="badge-group">
+          <span class="tag" *ngFor="let bookId of template.bookTemplateIds">
+            {{ (bookTemplates$ | async)?.find((book) => book.id === bookId)?.name || 'Unknown book' }}
+          </span>
+        </div>
+      </li>
+    </ul>
+  </ng-container>
+</section>
+<ng-template #emptyCatalogTemplates>
+  <p class="empty-state">No catalog templates yet. Connect book templates above.</p>
+</ng-template>

--- a/src/app/components/template-manager/template-manager.component.scss
+++ b/src/app/components/template-manager/template-manager.component.scss
@@ -1,0 +1,38 @@
+.field-builder {
+  background: #f8f9ff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.field-builder h4 {
+  margin: 0 0 0.75rem;
+}
+
+.field-list h4 {
+  margin-bottom: 0.75rem;
+}
+
+select[multiple] {
+  min-height: 160px;
+  background: #f9fafb;
+  border-radius: 10px;
+  padding: 0.5rem;
+}
+
+select[multiple] option {
+  padding: 0.35rem 0.5rem;
+}
+
+.section-description {
+  max-width: 720px;
+}
+
+h3 {
+  margin-bottom: 0.5rem;
+}
+
+h4 {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}

--- a/src/app/components/template-manager/template-manager.component.ts
+++ b/src/app/components/template-manager/template-manager.component.ts
@@ -1,0 +1,204 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { Observable } from 'rxjs';
+
+import {
+  BookTemplate,
+  CatalogTemplate,
+  FieldType,
+  PageTemplate,
+  PageTemplateField,
+} from '../../models/templates.model';
+import { TemplateStoreService } from '../../services/template-store.service';
+
+interface PageTemplateFormValue {
+  name: string;
+  description?: string;
+  fields: PageTemplateFieldDraft[];
+}
+
+interface PageTemplateFieldDraft {
+  name: string;
+  type: FieldType;
+  description?: string;
+}
+
+@Component({
+  selector: 'app-template-manager',
+  templateUrl: './template-manager.component.html',
+  styleUrls: ['./template-manager.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TemplateManagerComponent {
+  readonly pageTemplates$: Observable<PageTemplate[]> = this.store.pageTemplates$;
+  readonly bookTemplates$: Observable<BookTemplate[]> = this.store.bookTemplates$;
+  readonly catalogTemplates$: Observable<CatalogTemplate[]> = this.store.catalogTemplates$;
+
+  readonly fieldTypes: { value: FieldType; label: string }[] = [
+    { value: 'short-text', label: 'Short text' },
+    { value: 'long-text', label: 'Long text' },
+    { value: 'number', label: 'Number' },
+    { value: 'date', label: 'Date' },
+  ];
+
+  readonly pageTemplateForm = this.fb.group({
+    name: ['', Validators.required],
+    description: [''],
+    fields: this.fb.array<FormGroup>([], Validators.required),
+  });
+
+  readonly fieldDraftForm = this.fb.group({
+    name: ['', Validators.required],
+    type: ['short-text' as FieldType, Validators.required],
+    description: [''],
+  });
+
+  readonly bookTemplateForm = this.fb.group({
+    name: ['', Validators.required],
+    description: [''],
+    pageTemplateIds: new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] }),
+  });
+
+  readonly catalogTemplateForm = this.fb.group({
+    name: ['', Validators.required],
+    description: [''],
+    bookTemplateIds: new FormControl<string[]>([], { nonNullable: true, validators: [Validators.required] }),
+  });
+
+  constructor(private readonly fb: FormBuilder, private readonly store: TemplateStoreService) {}
+
+  get fields(): FormArray<FormGroup> {
+    return this.pageTemplateForm.get('fields') as FormArray<FormGroup>;
+  }
+
+  addField(): void {
+    if (this.fieldDraftForm.invalid) {
+      this.fieldDraftForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.fieldDraftForm.getRawValue();
+    this.fields.push(
+      this.fb.group({
+        name: [value.name.trim(), Validators.required],
+        type: [value.type, Validators.required],
+        description: [value.description?.trim() ?? ''],
+      })
+    );
+
+    this.pageTemplateForm.updateValueAndValidity();
+    this.fieldDraftForm.reset({ name: '', type: 'short-text', description: '' });
+  }
+
+  removeField(index: number): void {
+    this.fields.removeAt(index);
+    this.pageTemplateForm.updateValueAndValidity();
+  }
+
+  submitPageTemplate(): void {
+    if (this.pageTemplateForm.invalid || this.fields.length === 0) {
+      this.pageTemplateForm.markAllAsTouched();
+      return;
+    }
+
+    const formValue: PageTemplateFormValue = {
+      ...this.pageTemplateForm.getRawValue(),
+      fields: this.fields.controls.map((control) => ({
+        name: (control.value as PageTemplateFieldDraft).name.trim(),
+        type: (control.value as PageTemplateFieldDraft).type,
+        description: (control.value as PageTemplateFieldDraft).description?.trim(),
+      })),
+    };
+
+    const fields: PageTemplateField[] = formValue.fields.map((field) => ({
+      id: this.createId('field'),
+      name: field.name,
+      type: field.type,
+      description: field.description,
+    }));
+
+    this.store.createPageTemplate({
+      name: formValue.name.trim(),
+      description: formValue.description?.trim(),
+      fields,
+    });
+
+    this.resetPageTemplateForm();
+  }
+
+  submitBookTemplate(): void {
+    if (this.bookTemplateForm.invalid) {
+      this.bookTemplateForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.bookTemplateForm.getRawValue();
+    this.store.createBookTemplate({
+      name: value.name.trim(),
+      description: value.description?.trim(),
+      pageTemplateIds: [...value.pageTemplateIds],
+    });
+
+    this.bookTemplateForm.reset({ name: '', description: '', pageTemplateIds: [] });
+  }
+
+  submitCatalogTemplate(): void {
+    if (this.catalogTemplateForm.invalid) {
+      this.catalogTemplateForm.markAllAsTouched();
+      return;
+    }
+
+    const value = this.catalogTemplateForm.getRawValue();
+    this.store.createCatalogTemplate({
+      name: value.name.trim(),
+      description: value.description?.trim(),
+      bookTemplateIds: [...value.bookTemplateIds],
+    });
+
+    this.catalogTemplateForm.reset({ name: '', description: '', bookTemplateIds: [] });
+  }
+
+  deletePageTemplate(id: string): void {
+    this.store.removePageTemplate(id);
+  }
+
+  deleteBookTemplate(id: string): void {
+    this.store.removeBookTemplate(id);
+  }
+
+  deleteCatalogTemplate(id: string): void {
+    this.store.removeCatalogTemplate(id);
+  }
+
+  resetPageTemplateForm(): void {
+    this.pageTemplateForm.reset({ name: '', description: '', fields: [] });
+    this.fields.clear();
+    this.fieldDraftForm.reset({ name: '', type: 'short-text', description: '' });
+  }
+
+  getFieldLabel(type: FieldType): string {
+    const match = this.fieldTypes.find((item) => item.value === type);
+    return match?.label ?? type;
+  }
+
+  trackById<T extends { id: string }>(index: number, item: T): string {
+    return item.id;
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  resetAllData(): void {
+    this.store.resetAll();
+    this.resetPageTemplateForm();
+    this.bookTemplateForm.reset({ name: '', description: '', pageTemplateIds: [] });
+    this.catalogTemplateForm.reset({ name: '', description: '', bookTemplateIds: [] });
+  }
+
+  private createId(prefix: string): string {
+    const random = Math.random().toString(36).slice(2, 8);
+    const timestamp = Date.now().toString(36).slice(-4);
+    return `${prefix}-${timestamp}${random}`;
+  }
+}

--- a/src/app/components/viewer/viewer.component.html
+++ b/src/app/components/viewer/viewer.component.html
@@ -1,0 +1,232 @@
+<section class="card">
+  <h2>Content workspace</h2>
+  <p class="section-description">
+    Use the templates to assemble real pages, books, and catalogs. Everything persists in this browser via local storage.
+  </p>
+</section>
+
+<section class="card">
+  <form class="form-grid" [formGroup]="pageInstanceForm" (ngSubmit)="submitPageInstance()">
+    <h3>Create a page</h3>
+    <div class="form-grid two-column">
+      <label>
+        Template
+        <select formControlName="templateId">
+          <option value="" disabled>Select a page template</option>
+          <option *ngFor="let template of pageTemplates" [value]="template.id">{{ template.name }}</option>
+        </select>
+      </label>
+      <label>
+        Internal title
+        <input type="text" formControlName="title" placeholder="Marketing overview" />
+      </label>
+    </div>
+
+    <ng-container *ngIf="pageInstanceForm.get('templateId')?.value as pageTemplateId">
+      <div formGroupName="values" class="data-grid">
+        <div class="select-field" *ngFor="let field of pageTemplateFields(pageTemplateId)?.fields ?? []">
+          <label [attr.for]="field.id">
+            {{ field.name }}
+            <span class="muted" *ngIf="field.description">{{ field.description }}</span>
+          </label>
+          <ng-container [ngSwitch]="field.type">
+            <input
+              *ngSwitchCase="'short-text'"
+              type="text"
+              [formControlName]="field.id"
+              [id]="field.id"
+              placeholder="Enter {{ field.name | lowercase }}"
+            />
+            <textarea
+              *ngSwitchCase="'long-text'"
+              [formControlName]="field.id"
+              [id]="field.id"
+              placeholder="Enter {{ field.name | lowercase }}"
+            ></textarea>
+            <input
+              *ngSwitchCase="'number'"
+              type="number"
+              [formControlName]="field.id"
+              [id]="field.id"
+              placeholder="Enter {{ field.name | lowercase }}"
+            />
+            <input
+              *ngSwitchCase="'date'"
+              type="date"
+              [formControlName]="field.id"
+              [id]="field.id"
+            />
+            <input
+              *ngSwitchDefault
+              type="text"
+              [formControlName]="field.id"
+              [id]="field.id"
+              placeholder="Enter {{ field.name | lowercase }}"
+            />
+          </ng-container>
+        </div>
+      </div>
+    </ng-container>
+
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save page</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Saved pages</h3>
+  <ul class="list" *ngIf="pageInstances.length > 0; else emptyPages">
+    <li class="list-item" *ngFor="let page of pageInstances; trackBy: trackById">
+      <div class="section-header">
+        <div>
+          <strong>{{ page.title }}</strong>
+          <p class="muted">{{ pageTemplateName(page.templateId) }}</p>
+        </div>
+        <button class="btn btn-secondary" type="button" (click)="deletePageInstance(page.id)">Delete</button>
+      </div>
+      <div class="badge-group">
+        <span class="tag" *ngFor="let field of pageTemplateFields(page.templateId)?.fields ?? []">
+          {{ field.name }}: {{ page.values[field.id] || '—' }}
+        </span>
+      </div>
+    </li>
+  </ul>
+</section>
+<ng-template #emptyPages>
+  <p class="empty-state">Save a page to see it here.</p>
+</ng-template>
+
+<section class="card">
+  <form class="form-grid" [formGroup]="bookInstanceForm" (ngSubmit)="submitBookInstance()">
+    <h3>Assemble a book</h3>
+    <div class="form-grid two-column">
+      <label>
+        Template
+        <select formControlName="templateId">
+          <option value="" disabled>Select a book template</option>
+          <option *ngFor="let template of bookTemplates" [value]="template.id">{{ template.name }}</option>
+        </select>
+      </label>
+      <label>
+        Title
+        <input type="text" formControlName="title" placeholder="Q2 campaign book" />
+      </label>
+    </div>
+
+    <ng-container *ngIf="bookInstanceForm.get('templateId')?.value as bookTemplateId">
+      <ng-container *ngIf="bookTemplates.find((template) => template.id === bookTemplateId) as selectedBookTemplate">
+        <div formArrayName="pageSelections" class="data-grid">
+          <div class="select-field" *ngFor="let control of bookPageSelections.controls; let i = index">
+            <label>
+              {{ pageTemplateName(selectedBookTemplate.pageTemplateIds[i]) }}
+            </label>
+            <select [formControlName]="i">
+              <option value="">Select a page</option>
+              <option
+                *ngFor="let page of pagesForTemplate(selectedBookTemplate.pageTemplateIds[i])"
+                [value]="page.id"
+              >
+                {{ page.title }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
+
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save book</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Saved books</h3>
+  <ul class="list" *ngIf="bookInstances.length > 0; else emptyBooks">
+    <li class="list-item" *ngFor="let book of bookInstances; trackBy: trackById">
+      <div class="section-header">
+        <div>
+          <strong>{{ book.title }}</strong>
+          <p class="muted">{{ bookTemplateName(book.templateId) }}</p>
+        </div>
+        <button class="btn btn-secondary" type="button" (click)="deleteBookInstance(book.id)">Delete</button>
+      </div>
+      <div class="badge-group">
+        <span class="tag" *ngFor="let pageId of book.pageInstanceIds">
+          {{ pageInstances.find((page) => page.id === pageId)?.title || 'Missing page' }}
+        </span>
+      </div>
+    </li>
+  </ul>
+</section>
+<ng-template #emptyBooks>
+  <p class="empty-state">Create a book to list it here.</p>
+</ng-template>
+
+<section class="card">
+  <form class="form-grid" [formGroup]="catalogInstanceForm" (ngSubmit)="submitCatalogInstance()">
+    <h3>Build a catalog</h3>
+    <div class="form-grid two-column">
+      <label>
+        Template
+        <select formControlName="templateId">
+          <option value="" disabled>Select a catalog template</option>
+          <option *ngFor="let template of catalogTemplates" [value]="template.id">{{ template.name }}</option>
+        </select>
+      </label>
+      <label>
+        Title
+        <input type="text" formControlName="title" placeholder="Summer highlights" />
+      </label>
+    </div>
+
+    <ng-container *ngIf="catalogInstanceForm.get('templateId')?.value as catalogTemplateId">
+      <ng-container *ngIf="catalogTemplates.find((template) => template.id === catalogTemplateId) as selectedCatalogTemplate">
+        <div formArrayName="bookSelections" class="data-grid">
+          <div class="select-field" *ngFor="let control of catalogBookSelections.controls; let i = index">
+            <label>
+              {{ bookTemplateName(selectedCatalogTemplate.bookTemplateIds[i]) }}
+            </label>
+            <select [formControlName]="i">
+              <option value="">Select a book</option>
+              <option
+                *ngFor="let book of booksForTemplate(selectedCatalogTemplate.bookTemplateIds[i])"
+                [value]="book.id"
+              >
+                {{ book.title }}
+              </option>
+            </select>
+          </div>
+        </div>
+      </ng-container>
+    </ng-container>
+
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save catalog</button>
+    </div>
+  </form>
+</section>
+
+<section class="card">
+  <h3>Saved catalogs</h3>
+  <ul class="list" *ngIf="catalogInstances.length > 0; else emptyCatalogs">
+    <li class="list-item" *ngFor="let catalog of catalogInstances; trackBy: trackById">
+      <div class="section-header">
+        <div>
+          <strong>{{ catalog.title }}</strong>
+          <p class="muted">{{ catalogTemplates.find((template) => template.id === catalog.templateId)?.name || 'Catalog' }}</p>
+        </div>
+        <button class="btn btn-secondary" type="button" (click)="deleteCatalogInstance(catalog.id)">Delete</button>
+      </div>
+      <div class="badge-group">
+        <span class="tag" *ngFor="let bookId of catalog.bookInstanceIds">
+          {{ bookInstances.find((book) => book.id === bookId)?.title || 'Missing book' }}
+        </span>
+      </div>
+    </li>
+  </ul>
+</section>
+<ng-template #emptyCatalogs>
+  <p class="empty-state">When you save a catalog it will appear here.</p>
+</ng-template>

--- a/src/app/components/viewer/viewer.component.scss
+++ b/src/app/components/viewer/viewer.component.scss
@@ -1,0 +1,25 @@
+h3 {
+  margin-bottom: 0.5rem;
+}
+
+select,
+input,
+textarea {
+  width: 100%;
+}
+
+.badge-group {
+  gap: 0.5rem;
+}
+
+.data-grid {
+  margin-top: 1rem;
+}
+
+.list-item .section-header {
+  align-items: flex-start;
+}
+
+.list-item .muted {
+  margin-top: 0.25rem;
+}

--- a/src/app/components/viewer/viewer.component.ts
+++ b/src/app/components/viewer/viewer.component.ts
@@ -1,0 +1,372 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import {
+  BookInstance,
+  BookTemplate,
+  CatalogInstance,
+  CatalogTemplate,
+  PageInstance,
+  PageTemplate,
+} from '../../models/templates.model';
+import { TemplateStoreService } from '../../services/template-store.service';
+
+@Component({
+  selector: 'app-viewer',
+  templateUrl: './viewer.component.html',
+  styleUrls: ['./viewer.component.scss'],
+})
+export class ViewerComponent implements OnInit, OnDestroy {
+  pageTemplates: PageTemplate[] = [];
+  bookTemplates: BookTemplate[] = [];
+  catalogTemplates: CatalogTemplate[] = [];
+
+  pageInstances: PageInstance[] = [];
+  bookInstances: BookInstance[] = [];
+  catalogInstances: CatalogInstance[] = [];
+
+  readonly pageInstanceForm = this.fb.group({
+    templateId: ['', Validators.required],
+    title: ['', Validators.required],
+    values: this.fb.group({}),
+  });
+
+  readonly bookInstanceForm = this.fb.group({
+    templateId: ['', Validators.required],
+    title: ['', Validators.required],
+    pageSelections: this.fb.array<FormControl<string | null>>([], Validators.required),
+  });
+
+  readonly catalogInstanceForm = this.fb.group({
+    templateId: ['', Validators.required],
+    title: ['', Validators.required],
+    bookSelections: this.fb.array<FormControl<string | null>>([], Validators.required),
+  });
+
+  private readonly subscriptions = new Subscription();
+
+  constructor(private readonly fb: FormBuilder, private readonly store: TemplateStoreService) {}
+
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.store.pageTemplates$.subscribe((templates) => {
+        this.pageTemplates = templates;
+        this.syncPageTemplateSelection();
+      })
+    );
+
+    this.subscriptions.add(
+      this.store.bookTemplates$.subscribe((templates) => {
+        this.bookTemplates = templates;
+        this.syncBookTemplateSelection();
+      })
+    );
+
+    this.subscriptions.add(
+      this.store.catalogTemplates$.subscribe((templates) => {
+        this.catalogTemplates = templates;
+        this.syncCatalogTemplateSelection();
+      })
+    );
+
+    this.subscriptions.add(
+      this.store.pageInstances$.subscribe((instances) => {
+        this.pageInstances = instances;
+        this.validateBookSelections();
+      })
+    );
+
+    this.subscriptions.add(
+      this.store.bookInstances$.subscribe((instances) => {
+        this.bookInstances = instances;
+        this.validateCatalogSelections();
+      })
+    );
+
+    this.subscriptions.add(
+      this.store.catalogInstances$.subscribe((instances) => {
+        this.catalogInstances = instances;
+      })
+    );
+
+    this.subscriptions.add(
+      this.pageInstanceForm
+        .get('templateId')!
+        .valueChanges.subscribe((templateId) => this.configurePageFields(templateId as string | null))
+    );
+
+    this.subscriptions.add(
+      this.bookInstanceForm
+        .get('templateId')!
+        .valueChanges.subscribe((templateId) => this.configureBookSelections(templateId as string | null))
+    );
+
+    this.subscriptions.add(
+      this.catalogInstanceForm
+        .get('templateId')!
+        .valueChanges.subscribe((templateId) => this.configureCatalogSelections(templateId as string | null))
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  get pageValueGroup(): FormGroup {
+    return this.pageInstanceForm.get('values') as FormGroup;
+  }
+
+  get bookPageSelections(): FormArray<FormControl<string | null>> {
+    return this.bookInstanceForm.get('pageSelections') as FormArray<FormControl<string | null>>;
+  }
+
+  get catalogBookSelections(): FormArray<FormControl<string | null>> {
+    return this.catalogInstanceForm.get('bookSelections') as FormArray<FormControl<string | null>>;
+  }
+
+  submitPageInstance(): void {
+    if (this.pageInstanceForm.invalid) {
+      this.pageInstanceForm.markAllAsTouched();
+      return;
+    }
+
+    const { templateId, title } = this.pageInstanceForm.getRawValue();
+    const template = this.pageTemplates.find((item) => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const values = this.pageValueGroup.getRawValue() as Record<string, string>;
+
+    this.store.createPageInstance({
+      templateId: template.id,
+      title: title.trim(),
+      values,
+    });
+
+    this.pageInstanceForm.reset({ templateId: template.id, title: '', values: {} });
+    this.configurePageFields(template.id);
+  }
+
+  submitBookInstance(): void {
+    if (this.bookInstanceForm.invalid || this.bookPageSelections.length === 0) {
+      this.bookInstanceForm.markAllAsTouched();
+      return;
+    }
+
+    const { templateId, title } = this.bookInstanceForm.getRawValue();
+    const template = this.bookTemplates.find((item) => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const selectedPages = this.bookPageSelections.controls.map((control) => control.value).filter((value): value is string => !!value);
+    if (selectedPages.length !== template.pageTemplateIds.length) {
+      this.bookPageSelections.markAllAsTouched();
+      return;
+    }
+
+    this.store.createBookInstance({
+      templateId: template.id,
+      title: title.trim(),
+      pageInstanceIds: selectedPages,
+    });
+
+    this.bookInstanceForm.reset({ templateId: template.id, title: '', pageSelections: [] });
+    this.configureBookSelections(template.id);
+  }
+
+  submitCatalogInstance(): void {
+    if (this.catalogInstanceForm.invalid || this.catalogBookSelections.length === 0) {
+      this.catalogInstanceForm.markAllAsTouched();
+      return;
+    }
+
+    const { templateId, title } = this.catalogInstanceForm.getRawValue();
+    const template = this.catalogTemplates.find((item) => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const selectedBooks = this.catalogBookSelections.controls
+      .map((control) => control.value)
+      .filter((value): value is string => !!value);
+
+    if (selectedBooks.length !== template.bookTemplateIds.length) {
+      this.catalogBookSelections.markAllAsTouched();
+      return;
+    }
+
+    this.store.createCatalogInstance({
+      templateId: template.id,
+      title: title.trim(),
+      bookInstanceIds: selectedBooks,
+    });
+
+    this.catalogInstanceForm.reset({ templateId: template.id, title: '', bookSelections: [] });
+    this.configureCatalogSelections(template.id);
+  }
+
+  deletePageInstance(id: string): void {
+    this.store.removePageInstance(id);
+  }
+
+  deleteBookInstance(id: string): void {
+    this.store.removeBookInstance(id);
+  }
+
+  deleteCatalogInstance(id: string): void {
+    this.store.removeCatalogInstance(id);
+  }
+
+  pageTemplateFields(templateId: string): PageTemplate | undefined {
+    return this.pageTemplates.find((template) => template.id === templateId);
+  }
+
+  pagesForTemplate(templateId: string): PageInstance[] {
+    return this.pageInstances.filter((page) => page.templateId === templateId);
+  }
+
+  booksForTemplate(templateId: string): BookInstance[] {
+    return this.bookInstances.filter((book) => book.templateId === templateId);
+  }
+
+  trackById<T extends { id: string }>(index: number, item: T): string {
+    return item.id;
+  }
+
+  pageTemplateName(templateId: string): string {
+    return this.pageTemplates.find((template) => template.id === templateId)?.name ?? 'Untitled page';
+  }
+
+  bookTemplateName(templateId: string): string {
+    return this.bookTemplates.find((template) => template.id === templateId)?.name ?? 'Untitled book';
+  }
+
+  private configurePageFields(templateId: string | null): void {
+    const group = this.pageValueGroup;
+    Object.keys(group.controls).forEach((controlName) => group.removeControl(controlName));
+
+    const template = templateId ? this.pageTemplates.find((item) => item.id === templateId) : undefined;
+    if (!template) {
+      return;
+    }
+
+    template.fields.forEach((field) => {
+      group.addControl(field.id, this.fb.control('', Validators.required));
+    });
+  }
+
+  private configureBookSelections(templateId: string | null): void {
+    const array = this.bookPageSelections;
+    array.clear();
+
+    const template = templateId ? this.bookTemplates.find((item) => item.id === templateId) : undefined;
+    if (!template) {
+      return;
+    }
+
+    template.pageTemplateIds.forEach(() => {
+      array.push(new FormControl<string | null>(null, Validators.required));
+    });
+  }
+
+  private configureCatalogSelections(templateId: string | null): void {
+    const array = this.catalogBookSelections;
+    array.clear();
+
+    const template = templateId ? this.catalogTemplates.find((item) => item.id === templateId) : undefined;
+    if (!template) {
+      return;
+    }
+
+    template.bookTemplateIds.forEach(() => {
+      array.push(new FormControl<string | null>(null, Validators.required));
+    });
+  }
+
+  private syncPageTemplateSelection(): void {
+    const selectedId = this.pageInstanceForm.get('templateId')!.value as string | null;
+    if (selectedId && !this.pageTemplates.some((template) => template.id === selectedId)) {
+      this.pageInstanceForm.reset({ templateId: '', title: '', values: {} });
+      return;
+    }
+
+    if (selectedId) {
+      this.configurePageFields(selectedId);
+    }
+  }
+
+  private syncBookTemplateSelection(): void {
+    const selectedId = this.bookInstanceForm.get('templateId')!.value as string | null;
+    if (selectedId && !this.bookTemplates.some((template) => template.id === selectedId)) {
+      this.bookInstanceForm.reset({ templateId: '', title: '', pageSelections: [] });
+      this.bookPageSelections.clear();
+      return;
+    }
+
+    if (selectedId) {
+      this.configureBookSelections(selectedId);
+    }
+  }
+
+  private syncCatalogTemplateSelection(): void {
+    const selectedId = this.catalogInstanceForm.get('templateId')!.value as string | null;
+    if (selectedId && !this.catalogTemplates.some((template) => template.id === selectedId)) {
+      this.catalogInstanceForm.reset({ templateId: '', title: '', bookSelections: [] });
+      this.catalogBookSelections.clear();
+      return;
+    }
+
+    if (selectedId) {
+      this.configureCatalogSelections(selectedId);
+    }
+  }
+
+  private validateBookSelections(): void {
+    const templateId = this.bookInstanceForm.get('templateId')!.value as string | null;
+    if (!templateId) {
+      return;
+    }
+
+    const template = this.bookTemplates.find((item) => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const validPageIds = new Set(this.pageInstances.filter((page) => template.pageTemplateIds.includes(page.templateId)).map((page) => page.id));
+    this.bookPageSelections.controls.forEach((control, index) => {
+      if (control.value && !validPageIds.has(control.value)) {
+        control.setValue(null);
+      }
+      if (!control.validator) {
+        control.addValidators(Validators.required);
+      }
+      control.updateValueAndValidity({ emitEvent: false });
+    });
+  }
+
+  private validateCatalogSelections(): void {
+    const templateId = this.catalogInstanceForm.get('templateId')!.value as string | null;
+    if (!templateId) {
+      return;
+    }
+
+    const template = this.catalogTemplates.find((item) => item.id === templateId);
+    if (!template) {
+      return;
+    }
+
+    const validBookIds = new Set(this.bookInstances.filter((book) => template.bookTemplateIds.includes(book.templateId)).map((book) => book.id));
+    this.catalogBookSelections.controls.forEach((control) => {
+      if (control.value && !validBookIds.has(control.value)) {
+        control.setValue(null);
+      }
+      if (!control.validator) {
+        control.addValidators(Validators.required);
+      }
+      control.updateValueAndValidity({ emitEvent: false });
+    });
+  }
+}

--- a/src/app/models/templates.model.ts
+++ b/src/app/models/templates.model.ts
@@ -1,0 +1,59 @@
+export type FieldType = 'short-text' | 'long-text' | 'number' | 'date';
+
+export interface PageTemplateField {
+  id: string;
+  name: string;
+  type: FieldType;
+  description?: string;
+}
+
+export interface PageTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  fields: PageTemplateField[];
+}
+
+export interface BookTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  pageTemplateIds: string[];
+}
+
+export interface CatalogTemplate {
+  id: string;
+  name: string;
+  description?: string;
+  bookTemplateIds: string[];
+}
+
+export interface PageInstance {
+  id: string;
+  templateId: string;
+  title: string;
+  values: Record<string, string>;
+}
+
+export interface BookInstance {
+  id: string;
+  templateId: string;
+  title: string;
+  pageInstanceIds: string[];
+}
+
+export interface CatalogInstance {
+  id: string;
+  templateId: string;
+  title: string;
+  bookInstanceIds: string[];
+}
+
+export interface TemplateState {
+  pageTemplates: PageTemplate[];
+  bookTemplates: BookTemplate[];
+  catalogTemplates: CatalogTemplate[];
+  pages: PageInstance[];
+  books: BookInstance[];
+  catalogs: CatalogInstance[];
+}

--- a/src/app/services/template-store.service.ts
+++ b/src/app/services/template-store.service.ts
@@ -1,0 +1,324 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, map } from 'rxjs';
+
+import {
+  BookInstance,
+  BookTemplate,
+  CatalogInstance,
+  CatalogTemplate,
+  PageInstance,
+  PageTemplate,
+  PageTemplateField,
+  TemplateState,
+} from '../models/templates.model';
+
+const STORAGE_KEY = 'developer-portal-template-state';
+
+function safeParseState(raw: string | null): TemplateState | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as TemplateState;
+    if (parsed && typeof parsed === 'object') {
+      return {
+        pageTemplates: parsed.pageTemplates ?? [],
+        bookTemplates: parsed.bookTemplates ?? [],
+        catalogTemplates: parsed.catalogTemplates ?? [],
+        pages: parsed.pages ?? [],
+        books: parsed.books ?? [],
+        catalogs: parsed.catalogs ?? [],
+      };
+    }
+  } catch (error) {
+    console.warn('Unable to read stored template state', error);
+  }
+
+  return null;
+}
+
+const defaultState: TemplateState = {
+  pageTemplates: [],
+  bookTemplates: [],
+  catalogTemplates: [],
+  pages: [],
+  books: [],
+  catalogs: [],
+};
+
+@Injectable({ providedIn: 'root' })
+export class TemplateStoreService {
+  private readonly stateSubject = new BehaviorSubject<TemplateState>(this.loadState());
+  readonly state$ = this.stateSubject.asObservable();
+
+  readonly pageTemplates$ = this.state$.pipe(map((state) => state.pageTemplates));
+  readonly bookTemplates$ = this.state$.pipe(map((state) => state.bookTemplates));
+  readonly catalogTemplates$ = this.state$.pipe(map((state) => state.catalogTemplates));
+  readonly pageInstances$ = this.state$.pipe(map((state) => state.pages));
+  readonly bookInstances$ = this.state$.pipe(map((state) => state.books));
+  readonly catalogInstances$ = this.state$.pipe(map((state) => state.catalogs));
+
+  createPageTemplate(input: { name: string; description?: string; fields: PageTemplateField[] }): PageTemplate {
+    const template: PageTemplate = {
+      id: this.createId('pt'),
+      ...input,
+      fields: input.fields.map((field) => ({ ...field })),
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      pageTemplates: [...this.stateSubject.value.pageTemplates, template],
+    });
+
+    return template;
+  }
+
+  removePageTemplate(templateId: string): void {
+    const current = this.stateSubject.value;
+    const pagesToRemove = new Set(current.pages.filter((page) => page.templateId === templateId).map((page) => page.id));
+
+    const remainingPages = current.pages.filter((page) => page.templateId !== templateId);
+
+    const updatedBooks = current.books
+      .map((book) => ({
+        ...book,
+        pageInstanceIds: book.pageInstanceIds.filter((id) => !pagesToRemove.has(id)),
+      }))
+      .filter((book) => book.pageInstanceIds.length > 0);
+
+    const updatedBookTemplates = current.bookTemplates
+      .map((bookTemplate) => {
+        const filteredPages = bookTemplate.pageTemplateIds.filter((id) => id !== templateId);
+        return { ...bookTemplate, pageTemplateIds: filteredPages };
+      })
+      .filter((template) => template.pageTemplateIds.length > 0);
+
+    const validBookTemplateIds = new Set(updatedBookTemplates.map((template) => template.id));
+    const booksAfterTemplateCleanup = updatedBooks.filter((book) => validBookTemplateIds.has(book.templateId));
+
+    const removedBookIds = new Set(
+      current.books.map((book) => book.id).filter((id) => !booksAfterTemplateCleanup.some((book) => book.id === id))
+    );
+
+    const cleanedCatalogs = current.catalogs
+      .map((catalog) => ({
+        ...catalog,
+        bookInstanceIds: catalog.bookInstanceIds.filter((id) => !removedBookIds.has(id)),
+      }))
+      .filter((catalog) => catalog.bookInstanceIds.length > 0);
+
+    const cleanedCatalogTemplates = current.catalogTemplates
+      .map((catalogTemplate) => ({
+        ...catalogTemplate,
+        bookTemplateIds: catalogTemplate.bookTemplateIds.filter((id) => validBookTemplateIds.has(id)),
+      }))
+      .filter((template) => template.bookTemplateIds.length > 0);
+
+    this.setState({
+      ...current,
+      pageTemplates: current.pageTemplates.filter((template) => template.id !== templateId),
+      pages: remainingPages,
+      bookTemplates: updatedBookTemplates,
+      books: booksAfterTemplateCleanup,
+      catalogTemplates: cleanedCatalogTemplates,
+      catalogs: cleanedCatalogs,
+    });
+  }
+
+  createBookTemplate(input: { name: string; description?: string; pageTemplateIds: string[] }): BookTemplate {
+    const template: BookTemplate = {
+      id: this.createId('bt'),
+      ...input,
+      pageTemplateIds: [...input.pageTemplateIds],
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      bookTemplates: [...this.stateSubject.value.bookTemplates, template],
+    });
+
+    return template;
+  }
+
+  removeBookTemplate(templateId: string): void {
+    const current = this.stateSubject.value;
+    const booksToRemove = new Set(current.books.filter((book) => book.templateId === templateId).map((book) => book.id));
+
+    const updatedCatalogs = current.catalogs.filter((catalog) => catalog.bookInstanceIds.every((id) => !booksToRemove.has(id)));
+
+    const updatedCatalogTemplates = current.catalogTemplates
+      .map((template) => ({
+        ...template,
+        bookTemplateIds: template.bookTemplateIds.filter((id) => id !== templateId),
+      }))
+      .filter((template) => template.bookTemplateIds.length > 0);
+
+    this.setState({
+      ...current,
+      bookTemplates: current.bookTemplates.filter((template) => template.id !== templateId),
+      books: current.books.filter((book) => book.templateId !== templateId),
+      catalogs: updatedCatalogs,
+      catalogTemplates: updatedCatalogTemplates,
+    });
+  }
+
+  createCatalogTemplate(input: { name: string; description?: string; bookTemplateIds: string[] }): CatalogTemplate {
+    const template: CatalogTemplate = {
+      id: this.createId('ct'),
+      ...input,
+      bookTemplateIds: [...input.bookTemplateIds],
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      catalogTemplates: [...this.stateSubject.value.catalogTemplates, template],
+    });
+
+    return template;
+  }
+
+  removeCatalogTemplate(templateId: string): void {
+    const current = this.stateSubject.value;
+    this.setState({
+      ...current,
+      catalogTemplates: current.catalogTemplates.filter((template) => template.id !== templateId),
+      catalogs: current.catalogs.filter((catalog) => catalog.templateId !== templateId),
+    });
+  }
+
+  createPageInstance(input: { templateId: string; title: string; values: Record<string, string> }): PageInstance {
+    const instance: PageInstance = {
+      id: this.createId('p'),
+      ...input,
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      pages: [...this.stateSubject.value.pages, instance],
+    });
+
+    return instance;
+  }
+
+  removePageInstance(pageId: string): void {
+    const current = this.stateSubject.value;
+    const updatedBooks = current.books
+      .map((book) => ({
+        ...book,
+        pageInstanceIds: book.pageInstanceIds.filter((id) => id !== pageId),
+      }))
+      .filter((book) => book.pageInstanceIds.length > 0);
+
+    const removedBookIds = new Set(current.books.map((book) => book.id).filter((id) => !updatedBooks.some((book) => book.id === id)));
+
+    const updatedCatalogs = current.catalogs
+      .map((catalog) => ({
+        ...catalog,
+        bookInstanceIds: catalog.bookInstanceIds.filter((id) => !removedBookIds.has(id)),
+      }))
+      .filter((catalog) => catalog.bookInstanceIds.length > 0);
+
+    this.setState({
+      ...current,
+      pages: current.pages.filter((page) => page.id !== pageId),
+      books: updatedBooks,
+      catalogs: updatedCatalogs,
+    });
+  }
+
+  createBookInstance(input: { templateId: string; title: string; pageInstanceIds: string[] }): BookInstance {
+    const instance: BookInstance = {
+      id: this.createId('b'),
+      ...input,
+      pageInstanceIds: [...input.pageInstanceIds],
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      books: [...this.stateSubject.value.books, instance],
+    });
+
+    return instance;
+  }
+
+  removeBookInstance(bookId: string): void {
+    const current = this.stateSubject.value;
+    this.setState({
+      ...current,
+      books: current.books.filter((book) => book.id !== bookId),
+      catalogs: current.catalogs
+        .map((catalog) => ({
+          ...catalog,
+          bookInstanceIds: catalog.bookInstanceIds.filter((id) => id !== bookId),
+        }))
+        .filter((catalog) => catalog.bookInstanceIds.length > 0),
+    });
+  }
+
+  createCatalogInstance(input: { templateId: string; title: string; bookInstanceIds: string[] }): CatalogInstance {
+    const instance: CatalogInstance = {
+      id: this.createId('c'),
+      ...input,
+      bookInstanceIds: [...input.bookInstanceIds],
+    };
+
+    this.setState({
+      ...this.stateSubject.value,
+      catalogs: [...this.stateSubject.value.catalogs, instance],
+    });
+
+    return instance;
+  }
+
+  removeCatalogInstance(catalogId: string): void {
+    const current = this.stateSubject.value;
+    this.setState({
+      ...current,
+      catalogs: current.catalogs.filter((catalog) => catalog.id !== catalogId),
+    });
+  }
+
+  resetAll(): void {
+    this.setState({
+      pageTemplates: [],
+      bookTemplates: [],
+      catalogTemplates: [],
+      pages: [],
+      books: [],
+      catalogs: [],
+    });
+  }
+
+  private createId(prefix: string): string {
+    const random = Math.random().toString(36).slice(2, 8);
+    const timestamp = Date.now().toString(36).slice(-4);
+    return `${prefix}-${timestamp}${random}`;
+  }
+
+  private setState(state: TemplateState): void {
+    this.stateSubject.next(state);
+    this.persistState(state);
+  }
+
+  private loadState(): TemplateState {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+      return { ...defaultState };
+    }
+
+    const stored = safeParseState(window.localStorage.getItem(STORAGE_KEY));
+    return stored ?? { ...defaultState };
+  }
+
+  private persistState(state: TemplateState): void {
+    if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn('Unable to persist template state', error);
+    }
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false
+};

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DeveloperPortal</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,0 +1,214 @@
+@use "sass:color";
+
+:root {
+  --primary: #3f51b5;
+  --accent: #ffb74d;
+  --bg: #f4f5f7;
+  --text: #1a1a1a;
+  --border: #d8dae2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+.container {
+  margin: 0 auto;
+  padding: 1.5rem;
+  max-width: 1200px;
+}
+
+.card {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  border: 1px solid var(--border);
+}
+
+.card + .card {
+  margin-top: 1.5rem;
+}
+
+h1,
+h2,
+h3 {
+  color: #0f172a;
+  margin-top: 0;
+}
+
+section {
+  margin-bottom: 2.5rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  border-radius: 8px;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-primary {
+  background-color: var(--primary);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: color.scale(var(--primary), $lightness: -10%);
+}
+
+.btn-secondary {
+  background-color: #fff8f0;
+  color: #c47f1d;
+  border: 1px solid #f3d3a4;
+}
+
+.btn-secondary:hover {
+  background-color: #ffe4c2;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: #fff;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background-color: #eef2ff;
+  color: #3730a3;
+  margin-right: 0.25rem;
+}
+
+.empty-state {
+  color: #6b7280;
+  font-style: italic;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.inline-fields {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.inline-fields > * {
+  flex: 1;
+}
+
+.divider {
+  border: none;
+  border-top: 1px dashed var(--border);
+  margin: 1.5rem 0;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.section-description {
+  color: #4b5563;
+  margin: 0;
+}
+
+.data-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.data-grid.two-column {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.select-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+label {
+  font-weight: 600;
+}
+
+input[type="text"],
+textarea,
+select {
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background-color: #f9fafb;
+}
+
+textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.badge-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.muted {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+strong {
+  font-weight: 600;
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "lib": [
+      "es2022",
+      "dom"
+    ]
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "include": [
+    "src/**/*.spec.ts",
+    "src/test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- bootstrap an Angular workspace with routing, shared layout, and styling for the developer portal
- add a template store service that persists page, book, and catalog templates plus their instances in local storage with cascade cleanup
- build template manager and viewer experiences so users can define templates and compose content entirely in the browser

## Testing
- npm install *(fails: 403 Forbidden from registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf72b3f6688326a82706a34d16faf7